### PR TITLE
🧹 [code health improvement] Refactor React keys to use unique string properties instead of array indices in Page1

### DIFF
--- a/site/components/home/Page1.tsx
+++ b/site/components/home/Page1.tsx
@@ -74,9 +74,9 @@ function Page1() {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 xl:gap-10">
-          {features.map((feature, index) => (
+          {features.map((feature) => (
             <div 
-              key={index}
+              key={feature.title}
               className="group relative bg-white rounded-3xl p-8 shadow-sm border border-slate-100 hover:shadow-2xl hover:shadow-indigo-500/10 hover:-translate-y-2 transition-all duration-300"
             >
               {/* Top Gradient Border Line on Hover */}


### PR DESCRIPTION
🎯 What: Replaced array index with `feature.title` as the React key in `Page1` feature mapping.
💡 Why: Using array indices as keys in React is an anti-pattern. Using a unique string (`title`) improves the code health, prevents rendering bugs on array reordering, and follows React best practices. Also removed the unused `index` callback parameter to maintain clean code.
✅ Verification: Tested syntax/bundling locally with a lightweight bun build command.
✨ Result: `Page1.tsx` is cleaner and more robust when mapping the feature components.

---
*PR created automatically by Jules for task [2121734910778984422](https://jules.google.com/task/2121734910778984422) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved React component rendering efficiency by optimizing how list items are reconciled during updates, enhancing stability when item order changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->