### PR TITLE
chore: update Opus version 4.7 → 4.8

### DIFF
--- a/site/pages/docs/skills.mdx
+++ b/site/pages/docs/skills.mdx
@@ -7,7 +7,7 @@ type: 快速开始
 首次接入 Pushy 时，推荐先安装 `react-native-update` Skill，再让支持 Skills 的 AI 编程工具根据你的项目结构自动完成大部分集成改动。只有当工程结构特殊、需要精细控制，或者想逐项校对生成代码时，再回到后续手动文档。
 
 :::tip AI 模型服务
-本站同时提供 [AI 模型转发服务](https://ai.cresc.dev)：提供纯正官方 GPT-5.5 和 Claude Opus 4.7 模型，价格实惠、服务稳定、绝不掺水、数据安全。
+本站同时提供 [AI 模型转发服务](https://ai.cresc.dev)：提供纯正官方 GPT-5.5 和 Claude Opus 4.8 模型，价格实惠、服务稳定、绝不掺水、数据安全。
 :::
 
 ## Skill 信息


### PR DESCRIPTION
将文档中的 Claude Opus 4.7 更新为 Opus 4.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Opus version information in AI model documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/pushy-site/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->