### PR TITLE
docs(site): API Token 更名为 API Key，首页新增 MCP 服务卖点

### DIFF
--- a/site/components/home/Page1.tsx
+++ b/site/components/home/Page1.tsx
@@ -218,7 +218,35 @@ function Page1() {
 						</div>
 					</div>
 
-					{/* 6 — 技术支持（横向长卡） */}
+					{/* 6 — MCP 服务 */}
+					<div
+						data-reveal
+						style={{ "--reveal-delay": "240ms" } as CSSProperties}
+						className={cardBase}
+					>
+						{cardGlow}
+						<div className="relative">
+							<div className="flex items-center gap-4">
+								<FeatureIcon tint="bg-amber-500/10 text-amber-400">
+									<path d="M12 3l1.9 4.3L18 9l-4.1 1.7L12 15l-1.9-4.3L6 9l4.1-1.7L12 3z" />
+									<path d="M18 15l.9 2.1L21 18l-2.1.9L18 21l-.9-2.1L15 18l2.1-.9L18 15z" />
+								</FeatureIcon>
+								<h3 className="text-xl font-bold text-slate-50">MCP 服务</h3>
+							</div>
+							<p className="mt-3 text-[15px] leading-relaxed text-slate-400">
+								把 Pushy 接进 Claude Desktop、IDE 或自建 Agent，直接问“这台设备为什么没收到更新”，全程只读。
+							</p>
+							<a
+								href="/docs/mcp"
+								className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-amber-400 hover:text-amber-300 transition-colors"
+							>
+								了解 MCP 服务
+								<span aria-hidden="true">→</span>
+							</a>
+						</div>
+					</div>
+
+					{/* 7 — 技术支持（横向长卡） */}
 					<div data-reveal className={`${cardBase} lg:col-span-3`}>
 						{cardGlow}
 						<div className="relative flex flex-col sm:flex-row sm:items-center gap-6">

--- a/site/pages/docs/api-token.mdx
+++ b/site/pages/docs/api-token.mdx
@@ -1,14 +1,14 @@
 ---
 order: 12
-title: API Token
+title: API Key
 type: 开发指南
 ---
 
 
 
-# API Token
+# API Key
 
-API Token 是一种用于在 CI/CD 流程或自动化脚本中调用 [Pushy API](https://update.reactnative.cn/api/openapi) 的认证方式。相比直接使用账号密码，API Token 更加安全且便于管理。
+API Key 是一种用于在 CI/CD 流程或自动化脚本中调用 [Pushy API](https://update.reactnative.cn/api/openapi) 的认证方式。相比直接使用账号密码，API Key 更加安全且便于管理。
 
 ## 使用场景
 
@@ -16,18 +16,18 @@ API Token 是一种用于在 CI/CD 流程或自动化脚本中调用 [Pushy API]
 - **自动化脚本**：编写脚本批量管理应用、版本或原生包
 - **第三方工具集成**：将 Pushy 与其他开发工具集成
 
-## 创建 API Token
+## 创建 API Key
 
 1. 登录 [Pushy 管理后台](https://pushy-admin.reactnative.cn)
-2. 在左侧菜单中点击「API Token」
-3. 点击「创建 Token」按钮
-4. 填写 Token 名称（如：CI/CD Pipeline）
+2. 在左侧菜单中点击「API Key」
+3. 点击「创建 API Key」按钮
+4. 填写 API Key 名称（如：CI/CD Pipeline）
 5. 选择所需权限
 6. 可选设置过期时间
-7. 点击创建后，**立即复制并安全保存 Token**
+7. 点击创建后，**立即复制并安全保存 API Key**
 
 :::warning
-Token 只会在创建时显示一次，之后无法再次查看。请务必在创建后立即复制保存！
+API Key 只会在创建时显示一次，之后无法再次查看。请务必在创建后立即复制保存！
 :::
 
 ## 权限说明
@@ -39,21 +39,25 @@ Token 只会在创建时显示一次，之后无法再次查看。请务必在�
 | **删除 (delete)** | 删除应用、版本、原生包 |
 
 :::info
-创建 Token 时至少需要选择一个权限。根据实际需求选择最小必要权限是最佳实践。
+创建 API Key 时至少需要选择一个权限。根据实际需求选择最小必要权限是最佳实践。
 :::
 
-## 使用 Token 调用 API
+## 使用 API Key 调用 API
 
-在调用 Pushy API 时，将 Token 添加到请求头中：
+在调用 Pushy API 时，将 API Key 添加到请求头中：
 
 ```bash
 curl -X GET "https://update.reactnative.cn/api/app/list" \
   -H "x-api-token: YOUR_API_TOKEN"
 ```
 
+:::info
+请求头 `x-api-token` 与环境变量 `PUSHY_API_TOKEN` 是接口层面的名字，为兼容既有集成保持不变；页面与文档中统称 API Key，两者指的是同一样东西。
+:::
+
 ### 在命令行工具中使用
 
-如果使用 `react-native-update-cli` 命令行工具（需 v2.7.0+），可以通过环境变量设置 Token：
+如果使用 `react-native-update-cli` 命令行工具（需 v2.7.0+），可以通过环境变量设置 API Key：
 
 ```bash
 export PUSHY_API_TOKEN=your_api_token_here
@@ -91,41 +95,41 @@ jobs:
 ```
 
 :::tip
-在 CI/CD 环境中，建议将 Token 存储在密钥管理中（如 GitHub Secrets），而不是直接写入代码。
+在 CI/CD 环境中，建议将 API Key 存储在密钥管理中（如 GitHub Secrets），而不是直接写入代码。
 :::
 
-## 管理 Token
+## 管理 API Key
 
-### 查看 Token 列表
+### 查看 API Key 列表
 
-在「API Token」页面可以看到所有已创建的 Token，包括：
-- Token 名称
+在「API Key」页面可以看到所有已创建的 API Key，包括：
+- API Key 名称
 - 权限
 - 过期时间
 - 最后使用时间
 - 状态（正常/已过期/已撤销）
 
-### 撤销 Token
+### 撤销 API Key
 
-如果 Token 泄露或不再需要，可以随时撤销：
+如果 API Key 泄露或不再需要，可以随时撤销：
 
-1. 在 Token 列表中找到目标 Token
+1. 在 API Key 列表中找到目标 API Key
 2. 点击「撤销」按钮
 3. 确认撤销
 
 :::warning
-Token 撤销后立即生效，使用该 Token 的所有请求将被拒绝。请确保在撤销前更新相关的 CI/CD 配置。
+API Key 撤销后立即生效，使用该 API Key 的所有请求将被拒绝。请确保在撤销前更新相关的 CI/CD 配置。
 :::
 
 ## 安全建议
 
-1. **最小权限原则**：只授予 Token 必要的权限
-2. **设置过期时间**：为临时使用的 Token 设置合理的过期时间
-3. **定期轮换**：定期撤销旧 Token 并创建新 Token
-4. **安全存储**：不要将 Token 提交到代码仓库，使用环境变量或密钥管理工具
-5. **监控使用**：定期检查 Token 的最后使用时间，及时清理不再使用的 Token
+1. **最小权限原则**：只授予 API Key 必要的权限
+2. **设置过期时间**：为临时使用的 API Key 设置合理的过期时间
+3. **定期轮换**：定期撤销旧 API Key 并创建新 API Key
+4. **安全存储**：不要将 API Key 提交到代码仓库，使用环境变量或密钥管理工具
+5. **监控使用**：定期检查 API Key 的最后使用时间，及时清理不再使用的 API Key
 
 ## 限制
 
-- 每个用户最多可创建 **10 个** API Token
-- 如需创建更多，请先撤销不再使用的 Token
+- 每个用户最多可创建 **10 个** API Key
+- 如需创建更多，请先撤销不再使用的 API Key

--- a/site/rspress.config.ts
+++ b/site/rspress.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
           text: '高阶用法',
           items: [
             { text: 'API 文档', link: '/docs/api' },
-            { text: 'API Token', link: '/docs/api-token' },
+            { text: 'API Key', link: '/docs/api-token' },
             { text: 'MCP 服务', link: '/docs/mcp' },
             { text: '命令行工具', link: '/docs/cli' },
             { text: '场景实践', link: '/docs/bestpractice' },


### PR DESCRIPTION
## 改了什么

**1. API Token → API Key**

`/docs/api-token` 全文改称 API Key，侧边栏条目同步改名。**链接路径 `/docs/api-token` 保持不变** —— 改路径会断掉站外链接和控制台里指向这里的链接。

文中新增一条说明：请求头 `x-api-token` 与环境变量 `PUSHY_API_TOKEN` 是接口层面的名字、为兼容既有集成保持不变，界面与文档统称 API Key，两者是同一样东西。不写这条的话，读者照着文档配 header 会困惑。

**2. 首页补 MCP 服务卡片**

"Why Pushy" 原本 5 张卡片 + 1 张长卡，三列布局下第二行是缺一格的。补上 MCP 服务这张正好填满，指向 `/docs/mcp`。文案一句话说清能力与边界：接进 Claude Desktop / IDE / 自建 Agent，直接问"这台设备为什么没收到更新"，全程只读。

## 验证

`rspress build` 通过，产物里能查到新卡片文案与改名后的文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/pushy-site/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788535393&installation_model_id=426977&pr_number=37&repository=reactnativecn%2Fpushy-site&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Fpushy-site%2Fpull%2F37&signature=61bdf09119f2eeb6b4074bdba56a0591772bba7274675e551e5264259476aba9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “MCP 服务” feature card with a link to MCP integration documentation.
  * Updated feature numbering for the technical support card.

* **Documentation**
  * Renamed “API Token” to “API Key” throughout the documentation and navigation.
  * Clarified that existing headers and environment variables remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->